### PR TITLE
fix: fix logic on subviews require lifecycle

### DIFF
--- a/src/reorderable-repeat.js
+++ b/src/reorderable-repeat.js
@@ -292,6 +292,12 @@ export class ReorderableRepeat extends AbstractRepeater {
     }
 
     this.strategy.instanceChanged(this, this.patchedItems);
+    this.taskQueue.queueMicroTask(() => {
+      this.views().forEach(view => {
+        this._unRegisterDnd(view);
+        this._registerDnd(view);
+      });
+    });
   }
 
   _captureAndRemoveMatcherBinding() {
@@ -325,14 +331,12 @@ export class ReorderableRepeat extends AbstractRepeater {
     let view = this.viewFactory.create();
     view.bind(bindingContext, overrideContext);
     this.viewSlot.add(view);
-    this._registerDnd(view);
   }
 
   insertView(index, bindingContext, overrideContext) {
     let view = this.viewFactory.create();
     view.bind(bindingContext, overrideContext);
     this.viewSlot.insert(index, view);
-    this._registerDnd(view);
   }
 
   moveView(sourceIndex, targetIndex) {
@@ -355,8 +359,6 @@ export class ReorderableRepeat extends AbstractRepeater {
   }
 
   updateBindings(view) {
-    this._unRegisterDnd(view);
-
     let j = view.bindings.length;
     while (j--) {
       updateOneTimeBinding(view.bindings[j]);
@@ -369,8 +371,6 @@ export class ReorderableRepeat extends AbstractRepeater {
         updateOneTimeBinding(binding);
       }
     }
-
-    this._registerDnd(view);
   }
 
   _additionalAttribute(view, attribute) {


### PR DESCRIPTION
The root cause is in ArrayRepeatStrategy, moveView and updateOverrideContext are two steps, but reorderable-repeat needs to update dnd resources after overrideContext is updated. Also, with moveView, all dnd resources need to be re-registered because of index changes, that also affects styling (css classes). More than that, when using reordering-group, addView/removeView could be called too, so need to move re-registration logic to right after instanceChanged(), with a delay to cater overrideContext update.

closes #11