### PR TITLE
Allow nesting in repeat.for

### DIFF
--- a/src/reorderable-repeat.js
+++ b/src/reorderable-repeat.js
@@ -442,6 +442,10 @@ export class ReorderableRepeat extends AbstractRepeater {
     } else if (typeof func === 'string') {
       let funcCall = this.scope.overrideContext.bindingContext[func];
 
+      if(!funcCall){
+        funcCall = this.scope.overrideContext.parentOverrideContext.bindingContext[func];
+      }
+
       if (typeof funcCall === 'function') {
         return funcCall.bind(this.scope.overrideContext.bindingContext);
       }

--- a/test/unit/call-after-recordering.spec.js
+++ b/test/unit/call-after-recordering.spec.js
@@ -60,6 +60,54 @@ describe('reorderable-repeat: primitive array', () => {
     });
   });
 
+  it('call after reordering with string when nested in a repeat.for', done => {
+    let seenItems;
+    let change;
+    function action(items, c) {
+      seenItems = items;
+      change = c;
+    }
+
+    component = StageComponent
+        .withResources(['resources/reorderable-repeat', 'resources/reorderable-after-reordering'])
+        .inView(`
+        <div repeat.for="col of nestedItems" style="display: inline-block">
+          <div style="height: 50px; width: 100px;"
+            reorderable-repeat.for="obj of col['items']"
+            reorderable-group="items"
+            reorderable-after-reordering="action">
+            \${obj}
+          </div>
+        </div>`)
+        .boundTo({nestedItems: [{'name':'a', items: [1, 2, 3]}, {'name':'b', items: [4, 5, 6]},{'name':'c', items: [7, 8, 9]}], action});
+
+    component.create(bootstrap).then(() => {
+      const reorderableRepeat = component.viewModel;
+
+      nq(() => {
+        fireEvent(reorderableRepeat.view(0).firstChild, 'mousedown', {which: 1, clientX: 20, clientY: 20});
+        // first small movement, this is where dnd starts
+        fireEvent(documentElement, 'mousemove', {which: 1, clientX: 20, clientY: 21});
+      });
+      nq(() => {
+        // move to bottom half of 2nd element
+        fireEvent(documentElement, 'mousemove', {which: 1, clientX: 20, clientY: 76});
+      });
+      nq(() => {
+        // drop on bottom half of 2nd element
+        fireEvent(documentElement, 'mouseup', {which: 1, clientX: 20, clientY: 76});
+      });
+      nq(() => {
+        expect(reorderableRepeat.dndService.isProcessing).toBeFalsy();
+      });
+      nq(() => {
+        expect(seenItems).toEqual([2, 1, 3]);
+        expect(change).toEqual({fromIndex: 0, toIndex: 1});
+      });
+      nq(done);
+    });
+  });
+
   it('call after reordering with call binding', done => {
     let seenItems;
     function action(items) {


### PR DESCRIPTION
To create a drag and drop aware kanban board with a variable number of columns it is necessary to be able to nest reorderable-repeat inside a repeat.for.

I have made a small change which seems to work OK, but as I am not so familiar with Karma, I could not get my test to run.