### PR TITLE
fix(reorderable-group-map): check for null items

### DIFF
--- a/src/reorderable-group-map.js
+++ b/src/reorderable-group-map.js
@@ -3,7 +3,9 @@ export class ReorderableGroupMap {
 
   add(repeater) {
     const {repeaterId, items} = repeater;
-    this._map.set(items, {group: () => repeater.type, repeaterId});
+    if(items) {
+      this._map.set(items, {group: () => repeater.type, repeaterId});
+    }
   }
 
   remove(repeater) {


### PR DESCRIPTION
This crashes if an element with the repeater is hidden and at the same time the items is changed.
`unbind` sets items to `null` before the task queue calls `repeater.add`.